### PR TITLE
Add Spring Boot Maven plugin to remaining services

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -9,7 +9,7 @@
     <version>0.1.0</version>
   </parent>
   <artifactId>api-gateway</artifactId>
-  <dependencies>
+    <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
@@ -24,5 +24,14 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-  </dependencies>
-</project>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
+  </project>

--- a/matching-service/pom.xml
+++ b/matching-service/pom.xml
@@ -9,7 +9,7 @@
     <version>0.1.0</version>
   </parent>
   <artifactId>matching-service</artifactId>
-  <dependencies>
+    <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
@@ -24,5 +24,14 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-  </dependencies>
-</project>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
+  </project>

--- a/quest-service/pom.xml
+++ b/quest-service/pom.xml
@@ -9,7 +9,7 @@
     <version>0.1.0</version>
   </parent>
   <artifactId>quest-service</artifactId>
-  <dependencies>
+    <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
@@ -24,5 +24,14 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-  </dependencies>
-</project>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
+  </project>


### PR DESCRIPTION
## Summary
- ensure quest, matching, and gateway services apply the Spring Boot Maven plugin for consistent builds

## Testing
- `mvn -pl api-gateway,matching-service,quest-service test` *(fails: Non-resolvable import POM: spring-boot-dependencies:3.5.3 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b051c8f0d48329a322ad125e11d8b7