### PR TITLE
Centralize springdoc dependency version

### DIFF
--- a/adventurer-service/pom.xml
+++ b/adventurer-service/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.3.0</version>
+      <version>${springdoc-openapi.version}</version>
     </dependency>
   </dependencies>
 

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.3.0</version>
+      <version>${springdoc-openapi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/matching-service/pom.xml
+++ b/matching-service/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.3.0</version>
+      <version>${springdoc-openapi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <java.version>21</java.version>
     <spring-boot.version>3.5.3</spring-boot.version>
+    <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
   </properties>
 
   <dependencyManagement>

--- a/quest-service/pom.xml
+++ b/quest-service/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.3.0</version>
+      <version>${springdoc-openapi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- declare shared springdoc-openapi version property in parent
- reference parent property in all modules instead of hard-coded springdoc versions

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b054a0a1d0832988004b7d765fb6a7