### PR TITLE
Add basic QuestHub microservices implementation

### DIFF
--- a/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/Adventurer.java
+++ b/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/Adventurer.java
@@ -1,0 +1,50 @@
+package edu.ensign.cs460.questhub.adventurer;
+
+public class Adventurer {
+    private Long id;
+    private String name;
+    private int level;
+    private String characterClass;
+
+    public Adventurer() {
+    }
+
+    public Adventurer(Long id, String name, int level, String characterClass) {
+        this.id = id;
+        this.name = name;
+        this.level = level;
+        this.characterClass = characterClass;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public String getCharacterClass() {
+        return characterClass;
+    }
+
+    public void setCharacterClass(String characterClass) {
+        this.characterClass = characterClass;
+    }
+}

--- a/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerController.java
+++ b/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerController.java
@@ -1,0 +1,32 @@
+package edu.ensign.cs460.questhub.adventurer;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/adventurers")
+public class AdventurerController {
+    private final AdventurerService service;
+
+    public AdventurerController(AdventurerService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Adventurer create(@RequestBody Adventurer adventurer) {
+        return service.create(adventurer);
+    }
+
+    @GetMapping
+    public List<Adventurer> all() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Adventurer byId(@PathVariable Long id) {
+        return service.findById(id);
+    }
+}

--- a/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerService.java
+++ b/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerService.java
@@ -1,0 +1,48 @@
+package edu.ensign.cs460.questhub.adventurer;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class AdventurerService {
+    private final Map<Long, Adventurer> store = new HashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+    private static final Set<String> CLASSES = Set.of("Warrior", "Wizard", "Rogue");
+
+    public Adventurer create(Adventurer adventurer) {
+        validate(adventurer);
+        long id = idGenerator.getAndIncrement();
+        adventurer.setId(id);
+        store.put(id, adventurer);
+        return adventurer;
+    }
+
+    public List<Adventurer> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public Adventurer findById(Long id) {
+        Adventurer adv = store.get(id);
+        if (adv == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Adventurer not found");
+        }
+        return adv;
+    }
+
+    private void validate(Adventurer adventurer) {
+        if (!StringUtils.hasText(adventurer.getName())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Name must not be blank");
+        }
+        if (adventurer.getLevel() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Level must be >= 1");
+        }
+        if (!CLASSES.contains(adventurer.getCharacterClass())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid class");
+        }
+    }
+}

--- a/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerServiceApplication.java
+++ b/adventurer-service/src/main/java/edu/ensign/cs460/questhub/adventurer/AdventurerServiceApplication.java
@@ -1,0 +1,11 @@
+package edu.ensign.cs460.questhub.adventurer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AdventurerServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AdventurerServiceApplication.class, args);
+    }
+}

--- a/adventurer-service/src/test/java/edu/ensign/cs460/questhub/adventurer/AdventurerControllerTest.java
+++ b/adventurer-service/src/test/java/edu/ensign/cs460/questhub/adventurer/AdventurerControllerTest.java
@@ -1,0 +1,52 @@
+package edu.ensign.cs460.questhub.adventurer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdventurerControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void createAndFetchAdventurer() throws Exception {
+        Adventurer adv = new Adventurer(null, "Aragorn", 5, "Warrior");
+        mockMvc.perform(post("/adventurers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(adv)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists());
+
+        mockMvc.perform(get("/adventurers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Aragorn"));
+    }
+
+    @Test
+    void validationFailsForBadData() throws Exception {
+        Adventurer bad = new Adventurer(null, "", 0, "Mage");
+        mockMvc.perform(post("/adventurers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getByIdNotFound() throws Exception {
+        mockMvc.perform(get("/adventurers/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -11,12 +11,12 @@
   <artifactId>api-gateway</artifactId>
     <dependencies>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-gateway</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
       <version>${springdoc-openapi.version}</version>
     </dependency>
     <dependency>

--- a/api-gateway/src/main/java/edu/ensign/cs460/questhub/gateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/edu/ensign/cs460/questhub/gateway/ApiGatewayApplication.java
@@ -1,0 +1,11 @@
+package edu.ensign.cs460.questhub.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApiGatewayApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ApiGatewayApplication.class, args);
+    }
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: adventurer-service
+          uri: http://localhost:8081
+          predicates:
+            - Path=/api/adventurers/**
+          filters:
+            - StripPrefix=1
+        - id: quest-service
+          uri: http://localhost:8082
+          predicates:
+            - Path=/api/quests/**
+          filters:
+            - StripPrefix=1
+        - id: matching-service
+          uri: http://localhost:8083
+          predicates:
+            - Path=/api/match/**
+          filters:
+            - StripPrefix=1

--- a/api-gateway/src/test/java/edu/ensign/cs460/questhub/gateway/ApiGatewayApplicationTest.java
+++ b/api-gateway/src/test/java/edu/ensign/cs460/questhub/gateway/ApiGatewayApplicationTest.java
@@ -1,0 +1,20 @@
+package edu.ensign.cs460.questhub.gateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ApiGatewayApplicationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void routesAreConfigured() {
+        webTestClient.get().uri("/api/adventurers").exchange()
+                .expectStatus().is5xxServerError();
+    }
+}

--- a/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/Adventurer.java
+++ b/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/Adventurer.java
@@ -1,0 +1,26 @@
+package edu.ensign.cs460.questhub.matching;
+
+public class Adventurer {
+    private Long id;
+    private String name;
+    private int level;
+    private String characterClass;
+
+    public Adventurer() {}
+
+    public Adventurer(Long id, String name, int level, String characterClass) {
+        this.id = id;
+        this.name = name;
+        this.level = level;
+        this.characterClass = characterClass;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getLevel() { return level; }
+    public void setLevel(int level) { this.level = level; }
+    public String getCharacterClass() { return characterClass; }
+    public void setCharacterClass(String characterClass) { this.characterClass = characterClass; }
+}

--- a/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingController.java
+++ b/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingController.java
@@ -1,0 +1,21 @@
+package edu.ensign.cs460.questhub.matching;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class MatchingController {
+    private final MatchingService service;
+
+    public MatchingController(MatchingService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/match/{adventurerId}")
+    public List<Quest> match(@PathVariable Long adventurerId) {
+        return service.match(adventurerId);
+    }
+}

--- a/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingService.java
+++ b/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingService.java
@@ -1,0 +1,36 @@
+package edu.ensign.cs460.questhub.matching;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class MatchingService {
+    private final RestTemplate restTemplate;
+    private final String adventurerServiceUrl;
+    private final String questServiceUrl;
+
+    public MatchingService(RestTemplate restTemplate,
+                           @Value("${adventurer.service.url:http://localhost:8081}") String adventurerServiceUrl,
+                           @Value("${quest.service.url:http://localhost:8082}") String questServiceUrl) {
+        this.restTemplate = restTemplate;
+        this.adventurerServiceUrl = adventurerServiceUrl;
+        this.questServiceUrl = questServiceUrl;
+    }
+
+    public List<Quest> match(Long adventurerId) {
+        Adventurer adv = restTemplate.getForObject(adventurerServiceUrl + "/adventurers/" + adventurerId, Adventurer.class);
+        Quest[] quests = restTemplate.getForObject(questServiceUrl + "/quests", Quest[].class);
+        if (adv == null || quests == null) {
+            return List.of();
+        }
+        return Arrays.stream(quests)
+                .filter(q -> q.getDifficulty() <= adv.getLevel())
+                .filter(q -> q.getAllowedClass().equals(adv.getCharacterClass()) || q.getAllowedClass().equals("All"))
+                .collect(Collectors.toList());
+    }
+}

--- a/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingServiceApplication.java
+++ b/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/MatchingServiceApplication.java
@@ -1,0 +1,19 @@
+package edu.ensign.cs460.questhub.matching;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootApplication
+public class MatchingServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MatchingServiceApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/Quest.java
+++ b/matching-service/src/main/java/edu/ensign/cs460/questhub/matching/Quest.java
@@ -1,0 +1,34 @@
+package edu.ensign.cs460.questhub.matching;
+
+public class Quest {
+    private Long id;
+    private String title;
+    private int difficulty;
+    private int reward;
+    private String description;
+    private String allowedClass;
+
+    public Quest() {}
+
+    public Quest(Long id, String title, int difficulty, int reward, String description, String allowedClass) {
+        this.id = id;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.reward = reward;
+        this.description = description;
+        this.allowedClass = allowedClass;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public int getDifficulty() { return difficulty; }
+    public void setDifficulty(int difficulty) { this.difficulty = difficulty; }
+    public int getReward() { return reward; }
+    public void setReward(int reward) { this.reward = reward; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getAllowedClass() { return allowedClass; }
+    public void setAllowedClass(String allowedClass) { this.allowedClass = allowedClass; }
+}

--- a/matching-service/src/test/java/edu/ensign/cs460/questhub/matching/MatchingControllerTest.java
+++ b/matching-service/src/test/java/edu/ensign/cs460/questhub/matching/MatchingControllerTest.java
@@ -1,0 +1,51 @@
+package edu.ensign.cs460.questhub.matching;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MatchingControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void matchFiltersQuests() throws Exception {
+        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+        Adventurer adv = new Adventurer(1L, "Gandalf", 5, "Wizard");
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost:8081/adventurers/1"))
+                .andRespond(MockRestResponseCreators.withSuccess(objectMapper.writeValueAsString(adv), MediaType.APPLICATION_JSON));
+
+        Quest q1 = new Quest(1L, "Easy", 3, 10, "desc", "Wizard");
+        Quest q2 = new Quest(2L, "Hard", 10, 50, "desc", "Warrior");
+        Quest[] quests = {q1, q2};
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost:8082/quests"))
+                .andRespond(MockRestResponseCreators.withSuccess(objectMapper.writeValueAsString(quests), MediaType.APPLICATION_JSON));
+
+        mockMvc.perform(get("/match/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)));
+
+        server.verify();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <java.version>21</java.version>
     <spring-boot.version>3.5.3</spring-boot.version>
     <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+    <spring-cloud.version>2023.0.3</spring-cloud.version>
   </properties>
 
   <dependencyManagement>
@@ -29,6 +30,13 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/Quest.java
+++ b/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/Quest.java
@@ -1,0 +1,70 @@
+package edu.ensign.cs460.questhub.quest;
+
+public class Quest {
+    private Long id;
+    private String title;
+    private int difficulty;
+    private int reward;
+    private String description;
+    private String allowedClass;
+
+    public Quest() {
+    }
+
+    public Quest(Long id, String title, int difficulty, int reward, String description, String allowedClass) {
+        this.id = id;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.reward = reward;
+        this.description = description;
+        this.allowedClass = allowedClass;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(int difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public int getReward() {
+        return reward;
+    }
+
+    public void setReward(int reward) {
+        this.reward = reward;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getAllowedClass() {
+        return allowedClass;
+    }
+
+    public void setAllowedClass(String allowedClass) {
+        this.allowedClass = allowedClass;
+    }
+}

--- a/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestController.java
+++ b/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestController.java
@@ -1,0 +1,32 @@
+package edu.ensign.cs460.questhub.quest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/quests")
+public class QuestController {
+    private final QuestService service;
+
+    public QuestController(QuestService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Quest create(@RequestBody Quest quest) {
+        return service.create(quest);
+    }
+
+    @GetMapping
+    public List<Quest> all() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Quest byId(@PathVariable Long id) {
+        return service.findById(id);
+    }
+}

--- a/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestService.java
+++ b/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestService.java
@@ -1,0 +1,48 @@
+package edu.ensign.cs460.questhub.quest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class QuestService {
+    private final Map<Long, Quest> store = new HashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+    private static final Set<String> CLASSES = Set.of("Warrior", "Wizard", "Rogue", "All");
+
+    public Quest create(Quest quest) {
+        validate(quest);
+        long id = idGenerator.getAndIncrement();
+        quest.setId(id);
+        store.put(id, quest);
+        return quest;
+    }
+
+    public List<Quest> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public Quest findById(Long id) {
+        Quest q = store.get(id);
+        if (q == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Quest not found");
+        }
+        return q;
+    }
+
+    private void validate(Quest quest) {
+        if (!StringUtils.hasText(quest.getTitle()) || !StringUtils.hasText(quest.getDescription())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Title and description required");
+        }
+        if (quest.getDifficulty() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Difficulty must be >= 1");
+        }
+        if (!CLASSES.contains(quest.getAllowedClass())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid allowedClass");
+        }
+    }
+}

--- a/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestServiceApplication.java
+++ b/quest-service/src/main/java/edu/ensign/cs460/questhub/quest/QuestServiceApplication.java
@@ -1,0 +1,11 @@
+package edu.ensign.cs460.questhub.quest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class QuestServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(QuestServiceApplication.class, args);
+    }
+}

--- a/quest-service/src/test/java/edu/ensign/cs460/questhub/quest/QuestControllerTest.java
+++ b/quest-service/src/test/java/edu/ensign/cs460/questhub/quest/QuestControllerTest.java
@@ -1,0 +1,52 @@
+package edu.ensign.cs460.questhub.quest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QuestControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void createAndFetchQuest() throws Exception {
+        Quest quest = new Quest(null, "Find Ring", 3, 100, "Find the One Ring", "All");
+        mockMvc.perform(post("/quests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(quest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists());
+
+        mockMvc.perform(get("/quests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Find Ring"));
+    }
+
+    @Test
+    void validationFailsForBadData() throws Exception {
+        Quest bad = new Quest(null, "", 0, 0, "", "Mage");
+        mockMvc.perform(post("/quests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getByIdNotFound() throws Exception {
+        mockMvc.perform(get("/quests/99"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- implement Adventurer and Quest REST services with in-memory storage and validation
- add Matching service to call other services and filter quests for an adventurer
- configure API Gateway routes for microservices

## Testing
- `mvn clean verify` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b061a7510483299b380b058eb9a68a