### PR TITLE
Use zsh with git tooling in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,11 +7,18 @@
       "installMaven": "true",
       "mavenVersion": "3.9.9",
       "installGradle": "false"
+    },
+    "ghcr.io/devcontainers/features/oh-my-zsh:1": {
+      "plugins": "git"
     }
   },
+  "postCreateCommand": "git config --global pull.rebase false",
   "customizations": {
     "vscode": {
-      "settings": {"java.server.launchMode": "Standard"},
+      "settings": {
+        "java.server.launchMode": "Standard",
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      },
       "extensions": [
         "vscjava.vscode-java-pack",
         "vmware.vscode-spring-boot",
@@ -19,7 +26,8 @@
         "redhat.vscode-yaml",
         "esbenp.prettier-vscode",
         "vscode-icons-team.vscode-icons",
-        "github.copilot"
+        "github.copilot",
+        "eamodio.gitlens"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Configure dev container to install oh-my-zsh with git plugin
- Add VS Code GitLens extension and default zsh terminal
- Disable pull rebase in git config by default

## Testing
- `./grade-locally.sh` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0628811948329902aa318a29c87d4